### PR TITLE
Retry on 5xx Server Response

### DIFF
--- a/jsoncache.js
+++ b/jsoncache.js
@@ -9,7 +9,8 @@ class JSONCache {
     this.protocol = this.url.startsWith('https') ? https : http;
 
     this.timeout = timeout;
-    this.retryCount = maxRetry || 30;
+    this.maxRetry = maxRetry || 30;
+    this.retryCount = 0;
     this.currentData = null;
     this.lastUpdated = null;
     this.updating = null;
@@ -45,6 +46,8 @@ class JSONCache {
   httpGet() {
     return new this.Promise((resolve, reject) => {
       const request = this.protocol.get(this.url, (response) => {
+        const body = [];
+
         if (response.statusCode < 200 || response.statusCode > 299) {
           if (response.statusCode > 499 && this.retryCount < 30) {
             this.retryCount++;
@@ -53,9 +56,13 @@ class JSONCache {
             reject(new Error(`Failed to load page, status code: ${response.statusCode}`));
           }
         }
-        const body = [];
-        response.on('data', chunk => body.push(chunk));
-        response.on('end', () => resolve(body.join('')));
+
+        else {
+          response.on('data', chunk => body.push(chunk));
+          response.on('end', () => {
+            resolve(body.join(''))
+          });
+        }
       });
       request.on('error', err => reject(err));
     });

--- a/jsoncache.js
+++ b/jsoncache.js
@@ -4,11 +4,12 @@ const http = require('http');
 const https = require('https');
 
 class JSONCache {
-  constructor(url, timeout, promiseLib = Promise) {
+  constructor(url, timeout, promiseLib = Promise, maxRetry) {
     this.url = url;
     this.protocol = this.url.startsWith('https') ? https : http;
 
     this.timeout = timeout;
+    this.retryCount = maxRetry || 30;
     this.currentData = null;
     this.lastUpdated = null;
     this.updating = null;
@@ -45,7 +46,12 @@ class JSONCache {
     return new this.Promise((resolve, reject) => {
       const request = this.protocol.get(this.url, (response) => {
         if (response.statusCode < 200 || response.statusCode > 299) {
-          reject(new Error(`Failed to load page, status code: ${response.statusCode}`));
+          if (response.statusCode > 499 && this.retryCount < 30) {
+            this.retryCount++;
+            setTimeout(() => this.httpGet().then(resolve), 1000);
+          } else {
+            reject(new Error(`Failed to load page, status code: ${response.statusCode}`));
+          }
         }
         const body = [];
         response.on('data', chunk => body.push(chunk));

--- a/jsoncache.js
+++ b/jsoncache.js
@@ -4,12 +4,12 @@ const http = require('http');
 const https = require('https');
 
 class JSONCache {
-  constructor(url, timeout, promiseLib = Promise, maxRetry) {
+  constructor(url, timeout, promiseLib = Promise, maxRetry = 30) {
     this.url = url;
     this.protocol = this.url.startsWith('https') ? https : http;
 
     this.timeout = timeout;
-    this.maxRetry = maxRetry || 30;
+    this.maxRetry = maxRetry;
     this.retryCount = 0;
     this.currentData = null;
     this.lastUpdated = null;
@@ -55,9 +55,7 @@ class JSONCache {
           } else {
             reject(new Error(`Failed to load page, status code: ${response.statusCode}`));
           }
-        }
-
-        else {
+        } else {
           response.on('data', chunk => body.push(chunk));
           response.on('end', () => {
             resolve(body.join(''))


### PR DESCRIPTION
Retry `httpGet()` on 5xx response with a 1s delay.
`maxRetry` param added. Defaults to 30 (Stack may overflow on too high retry count, since each retry attempt won't resolve until the last one does)